### PR TITLE
update predevals config

### DIFF
--- a/predevals-config.yml
+++ b/predevals-config.yml
@@ -18,7 +18,7 @@ targets:
 eval_sets:
 - eval_set_name: Full season
   round_filters:
-    min: '2024-11-30'
+    min: '2025-01-25'
   task_filters:
     location:
     - "Bronx"
@@ -34,7 +34,7 @@ eval_sets:
     - 3
 - eval_set_name: Last 4 weeks
   round_filters:
-    min: '2024-11-30'
+    min: '2025-01-25'
     n_last: 5
   task_filters:
     location:

--- a/predevals-config.yml
+++ b/predevals-config.yml
@@ -18,8 +18,8 @@ targets:
 eval_sets:
 - eval_set_name: Full season
   round_filters:
-    min: '2025-01-25'
+    min: '2025-02-15'
 - eval_set_name: Last 4 weeks
   round_filters:
-    min: '2025-01-25'
+    min: '2025-02-15'
     n_last: 5

--- a/predevals-config.yml
+++ b/predevals-config.yml
@@ -9,7 +9,7 @@ targets:
   relative_metrics:
   - wis
   - ae_median
-  baseline: EpiENGAGE-baseline
+  baseline: epiENGAGE-baseline
   disaggregate_by:
   - location
   - reference_date

--- a/predevals-config.yml
+++ b/predevals-config.yml
@@ -19,41 +19,7 @@ eval_sets:
 - eval_set_name: Full season
   round_filters:
     min: '2025-01-25'
-  task_filters:
-    location:
-    - "Bronx"
-    - "Brooklyn"
-    - "Manhattan"
-    - "Queens"
-    - "Staten Island"
-    - "NYC"
-    horizon:
-    - 0
-    - 1
-    - 2
-    - 3
 - eval_set_name: Last 4 weeks
   round_filters:
     min: '2025-01-25'
     n_last: 5
-  task_filters:
-    location:
-    - "Bronx"
-    - "Brooklyn"
-    - "Manhattan"
-    - "Queens"
-    - "Staten Island"
-    - "NYC"
-    horizon:
-    - 0
-    - 1
-    - 2
-    - 3
-task_id_text:
-  location:
-    'Bronx': Bronx
-    'Brooklyn': Brooklyn
-    'Manhattan': Manhattan
-    'Queens': Queens
-    'Staten Island': Staten Island
-    'NYC': New York City


### PR DESCRIPTION
This adds the correct minimum round ID and it removes the filtering by task ID.

I spoke with @elray1 about the multiple targets WRT to the task ID and we don't really know what the outcome will be, so I made the executive decision to remove the filters, especially since I got this error:

```r
! Error in predevals config file:
`task_id_text` must contain text values for all possible levels of task id variables. For task id variable "location", missing the following values: "Austin", "Houston",
"Dallas", "El Paso", and "San Antonio"
```

This along with https://github.com/reichlab/flu-metrocast/pull/58 and merging in the baseline model ( https://github.com/reichlab/flu-metrocast/pull/51) should allow the evaluations to work