### PR TITLE
Update build-data workflow and index page

### DIFF
--- a/.github/workflows/build-data.yaml
+++ b/.github/workflows/build-data.yaml
@@ -4,6 +4,10 @@ on:
     - cron: "33 17 * * 4" # every Thursday at 5:45PM UTC == 12:33PM EST
   pull_request:
     branches: [main]
+  push:
+    paths: 
+      - predtimechart-config.yml
+      - predevals-config.yml
   workflow_dispatch:
     inputs:
       regenerate:

--- a/pages/index.qmd
+++ b/pages/index.qmd
@@ -29,7 +29,8 @@ Currently, the project focuses on two regions:
     - El Paso: Culberson, El Paso, Hudspeth, Loving
     - San Antonio: Atascosa, Bandera, Bexar, Frio, Gonzales, Guadalupe, Kendall, La Salle, McMullen, Medina, Wilson, Zavala
     
-##### Models Included
+##  Models Included
+
 - epiENGAGE-GBQR : A machine learning method that combines gradient boosting and quantile regression to predict conditional quantiles
 - epiENGAGE-INFLAenza : A spatial time-series model that uses the R-INLA package for estimating forecast posterior distributions.
 - epiENGAGE-Copycat :  A pattern matching model that matches growth rate trends to historic growth rate curves.
@@ -37,14 +38,5 @@ Currently, the project focuses on two regions:
 - epiENGAGE-baseline : simple time series model as a reference model
 - epiENGAGE-ensemble_mean : An equally weighted mean ensemble that takes the mean at each quantile level of all eligible forecasts
 - epiENGAGE-log_norm : Linear pool (a.k.a. distributional mixture) ensemble of quantile forecast submissions.
-
-
-
-:::{.callout-note}
-
-Look at this note!
-
-:::
-
 
 


### PR DESCRIPTION
I did two things in this PR

1. update build-data workflow to run if either of the configuration files are updated.
2. remove the note at the bottom of the homepage and update the heading so that it flows logically (e.g. doesn't jump directly to a fourth-level heading)