### PR TITLE
Update predevals config: rounds_idx=1, add relative metrics, update eval dates

### DIFF
--- a/predevals-config.yml
+++ b/predevals-config.yml
@@ -1,7 +1,7 @@
 schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.0.1/config_schema.json
-rounds_idx: 0
+rounds_idx: 1
 targets:
-- target_id: ILI ED visits
+- target_id: ILI ED visits pct
   metrics:
   - wis
   - ae_median
@@ -22,6 +22,10 @@ targets:
   - ae_median
   - interval_coverage_50
   - interval_coverage_95
+  relative_metrics:
+  - wis
+  - ae_median
+  baseline: epiENGAGE-baseline
   disaggregate_by:
   - location
   - reference_date
@@ -30,8 +34,8 @@ targets:
 eval_sets:
 - eval_set_name: Full season
   round_filters:
-    min: '2025-01-25'
+    min: '2025-11-22'
 - eval_set_name: Last 4 weeks
   round_filters:
-    min: '2025-01-25'
+    min: '2025-11-22'
     n_last: 5


### PR DESCRIPTION
## Summary
- Update `rounds_idx` from 0 to 1 for 2025/2026 season tasks
- Change target_id from "ILI ED visits" to "ILI ED visits pct"
- Add `relative_metrics` section with wis, ae_median, and epiENGAGE-baseline for hospital admissions target
- Update eval set min dates to 2025-11-22

🤖 Generated with [Claude Code](https://claude.com/claude-code)